### PR TITLE
fix: replace $aggregate server-side call with client-side populate

### DIFF
--- a/src/api/validations/block.validation.js
+++ b/src/api/validations/block.validation.js
@@ -1,20 +1,25 @@
-const Joi = require("joi");
-const Block = require("../models/block.model");
+const Joi = require('joi');
+// const Block = require('../models/block.model');
 
 module.exports = {
   // GET /v1/blocks
   listBlocks: {
     query: {
-      page: Joi.number().min(1),
-      perPage: Joi.number()
-        .min(1)
-        .max(100),
-      block_id: Joi.string(),
-      block_num: Joi.number(),
-      prev_block_id: Joi.string(),
-      timestamp: Joi.date(),
-      producer_account_id: Joi.string().regex(/^[a-fA-F0-9]{24}$/),
-      unstaking_balance: Joi.number()
-    }
-  }
+      filter: Joi.string(),
+      sort: Joi.string(),
+      skip: Joi.number(),
+      limit: Joi.number(),
+      fields: Joi.string(),
+      // page: Joi.number().min(1),
+      // perPage: Joi.number()
+      //   .min(1)
+      //   .max(100),
+      // block_id: Joi.string(),
+      // block_num: Joi.number(),
+      // prev_block_id: Joi.string(),
+      // timestamp: Joi.date(),
+      // producer_account_id: Joi.string().regex(/^[a-fA-F0-9]{24}$/),
+      // unstaking_balance: Joi.number()
+    },
+  },
 };


### PR DESCRIPTION
- server-side aggregate pipeline was running into memory and max document size limits in MongoDB due to blocks having large numbers of transactions.  Move to client-side, using mongoose `populate()` to speed up performance and remove limitations.