### PR TITLE
fix: corrected default sorting on block/txn lists

### DIFF
--- a/src/api/models/block.model.js
+++ b/src/api/models/block.model.js
@@ -152,7 +152,7 @@ blockSchema.statics = {
    * @param {Object|String} [projection] - Mongoose `select()` arg denoting fields to include or exclude
    * @returns {Promise<Block[]>}
    */
-  list({ skip = 0, limit = 30, sort, filter, projection }) {
+  list({ skip = 0, limit = 30, sort = { timestamp: -1 }, filter, projection }) {
     const $match = isEmpty(filter) ? {} : filter;
     const $subSelect = {};
 

--- a/src/api/models/transaction.model.js
+++ b/src/api/models/transaction.model.js
@@ -117,7 +117,7 @@ transactionSchema.statics = {
    * @param {Object|String} [projection] - MongoDB $projection object denoting fields to include/exclude
    * @returns {Promise<Transaction[]>}
    */
-  list({ skip = 0, limit = 30, sort, filter, projection }) {
+  list({ skip = 0, limit = 30, sort = { createdAt: -1 }, filter, projection }) {
     const $match = isEmpty(filter) ? null : { $match: filter };
     const $lookup = {
       $lookup: {


### PR DESCRIPTION
- the list GET requests for blocks and transactions wasn't returning the "most recent" according to timestamp/creation.
- update blocks list to default sort on `timestamp` descending (most recent)
- updated txn list to default sort on `createdAt` descending (most recent).
- Thanks "Jordi Goyanes" for calling this out!